### PR TITLE
escape provider name

### DIFF
--- a/domp.gemspec
+++ b/domp.gemspec
@@ -6,7 +6,7 @@ require 'domp/version'
 Gem::Specification.new do |gem|
   gem.name  = "domp"
   gem.version = Domp::VERSION
-  gem.licence = 'MIT'
+  gem.license = 'MIT'
   gem.authors = ["Alexander Zaytsev"]
   gem.email = ["alexander@say26.com"]
   gem.description = %q{Devise Omniauth Multiple Providers}

--- a/lib/generators/domp/domp_generator.rb
+++ b/lib/generators/domp/domp_generator.rb
@@ -23,7 +23,7 @@ class DompGenerator < Rails::Generators::NamedBase
     providers.each do |provider|
       id = ask("#{provider.capitalize} application ID:")
       secret = ask("#{provider.capitalize} application secret:")
-      omniauth_config << "\n  config.omniauth :#{provider}, '#{id}', '#{secret}'\n"
+      omniauth_config << "\n  config.omniauth :'#{provider}', '#{id}', '#{secret}'\n"
     end
 
     inject_into_file 'config/initializers/devise.rb', after: "# config.omniauth :github, 'APP_ID', 'APP_SECRET', :scope => 'user,public_repo'" do

--- a/lib/generators/domp/domp_generator.rb
+++ b/lib/generators/domp/domp_generator.rb
@@ -23,7 +23,7 @@ class DompGenerator < Rails::Generators::NamedBase
     providers.each do |provider|
       id = ask("#{provider.capitalize} application ID:")
       secret = ask("#{provider.capitalize} application secret:")
-      omniauth_config << "\n  config.omniauth :'#{provider}', '#{id}', '#{secret}'\n"
+      omniauth_config << "\n  config.omniauth :#{provider.underscore}, '#{id}', '#{secret}'\n"
     end
 
     inject_into_file 'config/initializers/devise.rb', after: "# config.omniauth :github, 'APP_ID', 'APP_SECRET', :scope => 'user,public_repo'" do

--- a/lib/generators/domp/templates/omniauth_callbacks_controller.rb
+++ b/lib/generators/domp/templates/omniauth_callbacks_controller.rb
@@ -2,7 +2,7 @@
 class <%= class_name.pluralize %>::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
 <% providers.each do |provider| -%>
-  def <%= provider %>
+  def <%= provider.underscore %>
     create
   end
 


### PR DESCRIPTION
provider name may contein `-oauth2` and hence be an invalid symbol
