### PR TITLE
Make compatible with OmniAuth.config.mock_auth

### DIFF
--- a/lib/generators/domp/templates/model_authentication.rb
+++ b/lib/generators/domp/templates/model_authentication.rb
@@ -10,8 +10,8 @@ class <%= class_name %>Authentication < ActiveRecord::Base
 
 <% end -%>
   def self.create_from_omniauth(params, <%= class_name.downcase %>, provider)
+    params = HashWithIndifferentAccess.new(params)
     token_expires_at = params['credentials']['expires_at'] ? Time.at(params['credentials']['expires_at']).to_datetime : nil
-
     create(
       <%= class_name.downcase %>: <%= class_name.downcase %>,
       authentication_provider: provider,

--- a/lib/generators/domp/templates/omniauth_callbacks_controller.rb
+++ b/lib/generators/domp/templates/omniauth_callbacks_controller.rb
@@ -11,6 +11,10 @@ class <%= class_name.pluralize %>::OmniauthCallbacksController < Devise::Omniaut
 
     def create
       auth_params = request.env["omniauth.auth"]
+      unless auth_params.is_a?(OmniAuth::AuthHash)
+        auth_params = OmniAuth::AuthHash.new(auth_params)
+      end
+
       provider = AuthenticationProvider.where(name: auth_params.provider).first
 
       authentication = provider.<%= class_name.downcase %>_authentications.where(uid: auth_params.uid).first


### PR DESCRIPTION
Fixed two issues that make the controller and model authentication break tests using OmniAuth mocks.
See https://github.com/intridea/omniauth/wiki/Integration-Testing
