### PR TITLE
fixed issue with linking multiple providers with same email account.

### DIFF
--- a/lib/generators/domp/templates/omniauth_callbacks_controller.rb
+++ b/lib/generators/domp/templates/omniauth_callbacks_controller.rb
@@ -12,12 +12,14 @@ class <%= class_name.pluralize %>::OmniauthCallbacksController < Devise::Omniaut
     def create
       auth_params = request.env["omniauth.auth"]
       provider = AuthenticationProvider.where(name: auth_params.provider).first
-
+      email_matching_user = User.where('email = ?', auth_params['info']['email']).first
       authentication = provider.<%= class_name.downcase %>_authentications.where(uid: auth_params.uid).first
       if authentication
         sign_in_with_existing_authentication(authentication)
       elsif <%= class_name.downcase %>_signed_in?
         create_authentication_and_sign_in(auth_params, current_<%= class_name.downcase %>, provider)
+      elsif !<%= class_name.downcase %>_signed_in? and email_matching_user
+        create_authentication_and_sign_in(auth_params, email_matching_user, provider)         
       else
         create_<%= class_name.downcase %>_and_authentication_and_sign_in(auth_params, provider)
       end


### PR DESCRIPTION
There is some issue when we try to link two providers with the same email account.
E.g
1. Sign in with google.
2. Sign out.
3. Sign in with facebook.

Considering both accounts use the same email only new authentication model should be created for the user with email of google. 
That doesn't happen as right now the create method only checks for signed_in_user.
Fixed in this merge request
